### PR TITLE
Capture full protocol in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,65 @@
 # vertx-tcp-eventbus-bridge
 
-This is a TCP eventbus bridge implementation. The protocol is quite simple:
+This is a TCP eventbus bridge implementation.
+
+
+## The protocol
+
+The protocol is quite simple:
 
 * 4bytes int32 message length (big endian encoding)
-* json string
-* built-in keys
-	* type: (String, required) One of "send", "publish", "register", "unregister".
-	* headers: (Object, optional) Headers with JSON format. Value of string type is supported.
-	* body: (Object, optional) Message content in JSON format.
-	* address: (String, required) Destination address
-	* replyAddress: (String, optional) Address for replying to. If it's TcpEventBusBridge.REPLY_BACKTRACK, then it will reply back to the request end. 
+* json string (encoded in UTF-8)
+
+### Messages from the bridge -> client
+
+Every JSON message will include a `type` key, with a string
+value. Each type is shown below, along with the companion keys for
+that type:
+
+####  `type: "err"`
+
+* `message`: (string, required) The type of error, one of:
+  `"access_denied"`, `"address_required"`, `"unknown_address"`,
+  `"unknown_type"`
+
+#### `type: "message"`
+
+For a regular message, the object will also contain:
+
+* `address`: (string, required) Destination address.
+* `body`: (object, required) Message content as a JSON object.
+* `headers`: (object, optional) Headers as a JSON object with String values.
+* `replyAddress`: (string, optional) Address for replying to.
+
+When a message from the client requests a reply, and that reply fails,
+the object will instead contain:
+
+* `failureCode`: (number, required) The failure code
+* `failureType`: (string, required) The failure name
+* `message`: (string, required) The message from the exception that signaled the failure
+
+### Messages from the client -> bridge
+
+The JSON object must contain a `type` key with a string value.  Each
+type is shown below, along with the companion keys for that type:
+
+#### `type: "send"`, `type: "publish"`
+
+* `address`: (string, required) Destination address
+* `body`: (object, required) Message content as a JSON object.
+* `headers`: (object, optional) Headers as a JSON object with String values.
+* `replyAddress`: (string, optional) Address for replying to.
+
+#### `type: "register"`, `type: "unregister"`
+
+* `address`: (string, required) Destination address
+* `headers`: (object, optional) Headers as a JSON object with String values.
+
+#### `type: "ping"`
+
+`ping` requires no additional keys.
+
+## Example
 
 An example nodejs client is provided as an example using the same API as SockJS bridge e.g.:
 
@@ -25,3 +75,4 @@ eb.onopen = function () {
   });
 };
 ```
+


### PR DESCRIPTION
This documents the full protocol, including the shape of messages sent from the bridge to the client.

I found myself going to the bridge source to figure this out on multiple occasions, so decided to document it in the README.