### PR TITLE
Specify when a message is a send

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For a regular message, the object will also contain:
 * `body`: (object, required) Message content as a JSON object.
 * `headers`: (object, optional) Headers as a JSON object with String values.
 * `replyAddress`: (string, optional) Address for replying to.
+* `send`: (boolean, required) Will be `true` if the message is a send, `false` if a publish.
 
 When a message from the client requests a reply, and that reply fails,
 the object will instead contain:

--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeImpl.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeImpl.java
@@ -180,7 +180,7 @@ public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
                     replies.put(response.replyAddress(), response);
                   }
 
-                  sendFrame("message", replyAddress, response.replyAddress(), responseHeaders, response.body(), socket);
+                  sendFrame("message", replyAddress, response.replyAddress(), responseHeaders, true, response.body(), socket);
                 }
               });
             } else {
@@ -218,7 +218,7 @@ public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
                 responseHeaders.put(entry.getKey(), entry.getValue());
               }
 
-              sendFrame("message", res1.address(), res1.replyAddress(), responseHeaders, res1.body(), socket);
+              sendFrame("message", res1.address(), res1.replyAddress(), responseHeaders, res1.isSend(), res1.body(), socket);
             }));
           } else {
             sendErrFrame("access_denied", socket);


### PR DESCRIPTION
This expands the bridge -> client protocol to add a `send` key. It will
be `true` if the message is the result of a send, `false` if the result
of a publish.

Depends on https://github.com/eclipse/vert.x/commit/70b2b541e780d09e6c83cb434a2e977d6e3b550c

Fixes #20

Signed-off-by: Toby Crawley <toby@tcrawley.org>