### PR TITLE
Only deliver sends to one handler in the node client

### DIFF
--- a/src/client/nodejs/test/TcpEventBusBridgeEchoServer.java
+++ b/src/client/nodejs/test/TcpEventBusBridgeEchoServer.java
@@ -1,6 +1,7 @@
 package test;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.bridge.BridgeOptions;
@@ -11,20 +12,32 @@ public class TcpEventBusBridgeEchoServer {
 
   public static void main(String[] args) {
     Vertx vertx = Vertx.vertx();
+    EventBus eb = vertx.eventBus();
 
-    vertx.eventBus().consumer("hello", (Message<JsonObject> msg) -> {
+    eb.consumer("hello", (Message<JsonObject> msg) -> {
       msg.reply(new JsonObject().put("value", "Hello " + msg.body().getString("value")));
     });
 
-    vertx.eventBus().consumer("echo",
+    eb.consumer("echo",
         (Message<JsonObject> msg) -> msg.reply(msg.body()));
+
+    eb.consumer("echo2",
+                (Message<JsonObject> msg) -> {
+                  if ("send".equals(msg.body().getString("response_type"))) {
+                    eb.send("echo2_response", msg.body());
+                  } else {
+                    eb.publish("echo2_response", msg.body());
+                  }
+                });
 
     TcpEventBusBridge bridge = TcpEventBusBridge.create(
         vertx,
         new BridgeOptions()
             .addInboundPermitted(new PermittedOptions().setAddress("hello"))
             .addInboundPermitted(new PermittedOptions().setAddress("echo"))
-            .addOutboundPermitted(new PermittedOptions().setAddress("echo")));
+            .addOutboundPermitted(new PermittedOptions().setAddress("echo"))
+            .addInboundPermitted(new PermittedOptions().setAddress("echo2"))
+            .addOutboundPermitted(new PermittedOptions().setAddress("echo2_response")));
 
     bridge.listen(7000, res -> System.out.println("Ready"));
   }

--- a/src/client/nodejs/test/index.js
+++ b/src/client/nodejs/test/index.js
@@ -25,3 +25,78 @@ describe('echo test', function () {
     };
   });
 });
+
+
+describe('send v. publish', function () {
+  it('should deliver sends to one listener', function (done) {
+    var eb = new EventBus('localhost', 7000);
+
+    eb.onerror = function (err) {
+      console.error(err);
+      assert.fail();
+    };
+
+    var messages = [];
+    
+    var handler = function (err, msg) {
+      if (err) {
+        assert.fail();
+        return;
+      }
+      
+      messages.push(msg);
+    };
+    
+    eb.onopen = function () {
+      eb.registerHandler("echo2_response", handler);
+      eb.registerHandler("echo2_response", handler);
+
+      setTimeout(function () {
+        assert.equal(messages.length, 1);
+        done();
+      }, 50);
+      
+      eb.send('echo2', {response_type: 'send'}, function (err, res) {
+        if (err) {
+          assert.fail();
+        }
+      });
+    };
+  });
+
+  it('should deliver publishes to every listener', function (done) {
+    var eb = new EventBus('localhost', 7000);
+
+    eb.onerror = function (err) {
+      console.error(err);
+      assert.fail();
+    };
+
+    var messages = [];
+    
+    var handler = function (err, msg) {
+      if (err) {
+        assert.fail();
+        return;
+      }
+      
+      messages.push(msg);
+    };
+    
+    eb.onopen = function () {
+      eb.registerHandler("echo2_response", handler);
+      eb.registerHandler("echo2_response", handler);
+
+      setTimeout(function () {
+        assert.equal(messages.length, 2);
+        done();
+      }, 50);
+      
+      eb.send('echo2', {response_type: 'publish'}, function (err, res) {
+        if (err) {
+          assert.fail();
+        }
+      });
+    };
+  });
+});


### PR DESCRIPTION
This uses the new `send` key to know if a message should be delivered to
one or all handlers. This also fixes the behavior when an error message
is received - error messages that are directed at addresses are of type
"message", not "err". "err" messages a general, and have no address, so
should only go to the global error handler.

Related to #20

This is dependent on #23.
