### PR TITLE
Fix to "Unregistering a consumer fails"

### DIFF
--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeImpl.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeImpl.java
@@ -400,6 +400,8 @@ public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
         return BridgeEventType.SOCKET_PING;
       case "register":
         return BridgeEventType.REGISTER;
+      case "unregister":
+        return BridgeEventType.UNREGISTER;
       case "publish":
         return BridgeEventType.PUBLISH;
       case "send":


### PR DESCRIPTION
This fixes https://github.com/vert-x3/vertx-tcp-eventbus-bridge/issues/34.

Tested TcpBusTest/testUnsubscribe against this branch. Worked fine. Please accept.