### PR TITLE
Security Update

### DIFF
--- a/src/client/nodejs/lib/tcp-vertx-eventbus.js
+++ b/src/client/nodejs/lib/tcp-vertx-eventbus.js
@@ -47,7 +47,7 @@ function send(transport, message) {
   message = Buffer.from(message, "utf-8");
   var msgLen = message.length;
 
-  var buffer = new Buffer(4);
+  var buffer =  Buffer.alloc(4);
   buffer.writeInt32BE(msgLen, 0);
 
   transport.write(Buffer.concat([buffer, message], 4 + msgLen));
@@ -101,7 +101,7 @@ var EventBus = function (host, port, options) {
   this.onerror = console.error;
 
   // message buffer
-  var buffer = new Buffer(0);
+  var buffer =  Buffer.alloc(0);
   var len    = 0;
 
   this.transport.on('close', function () {


### PR DESCRIPTION
new Buffer(num) decprecated due to security issues, the new method Buffer.alloc(num) was introduced to fix the problem, an update was made to refix the security problem.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
