### PR TITLE
[Issue-58] No response when wrong format messages are sent to bridge

### DIFF
--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeHandler.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeHandler.java
@@ -114,8 +114,17 @@ class TcpEventBusBridgeHandler implements Handler<NetSocket> {
 
   private void doSendOrPub(NetSocket socket, String address, JsonObject msg, Map<String,
     MessageConsumer<?>> registry, Map<String, Message<JsonObject>> replies) {
-    final JsonObject body = msg.getJsonObject("body");
-    final JsonObject headers = msg.getJsonObject("headers");
+    final Object body = msg.getValue("body");
+    if (body != null && !(body instanceof JsonObject)) {
+      sendErrFrame("wrong_format", socket);
+      return;
+    }
+    final Object headersValue = msg.getValue("headers");
+    if (headersValue != null && !(headersValue instanceof JsonObject)) {
+      sendErrFrame("wrong_format", socket);
+      return;
+    }
+    final JsonObject headers = (JsonObject)headersValue;
 
     // default to message
     final String type = msg.getString("type", "message");

--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeHandler.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeHandler.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.eventbus.bridge.tcp.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.NetSocket;
+import io.vertx.ext.bridge.BridgeEventType;
+import io.vertx.ext.eventbus.bridge.tcp.BridgeEvent;
+import io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameHelper.sendErrFrame;
+import static io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameHelper.sendFrame;
+
+/**
+ * The EventBus Bridge Handler to handle all socket operations.
+ *
+ * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+class TcpEventBusBridgeHandler implements Handler<NetSocket> {
+
+  private static final Logger log = LoggerFactory.getLogger(TcpEventBusBridgeHandler.class);
+
+  private final Map<String, MessageConsumer<?>> registry = new ConcurrentHashMap<>();
+  private final Map<String, Message<JsonObject>> replies = new ConcurrentHashMap<>();
+
+  private final TcpEventBusBridgeImpl bridge;
+  private final EventBus eventBus;
+  private final Handler<BridgeEvent> bridgeEventHandler;
+
+  TcpEventBusBridgeHandler(TcpEventBusBridgeImpl bridge, EventBus eventBus, Handler<BridgeEvent> bridgeEventHandler) {
+    this.bridge = bridge;
+    this.eventBus = eventBus;
+    this.bridgeEventHandler = bridgeEventHandler;
+  }
+
+  @Override
+  public void handle(NetSocket socket) {
+
+    // create a protocol parser
+    final FrameParser parser = new FrameParser(res -> {
+      if (res.failed()) {
+        // could not parse the message properly
+        log.error(res.cause());
+        return;
+      }
+
+      final JsonObject msg = res.result();
+
+      // short reference
+
+      // default to message
+      final String type = msg.getString("type", "message");
+      final String address = msg.getString("address");
+      BridgeEventType eventType = parseType(type);
+      checkCallHook(() -> new BridgeEventImpl(eventType, msg, socket),
+        () -> {
+          if (eventType != BridgeEventType.SOCKET_PING && address == null) {
+            sendErrFrame("missing_address", socket);
+            log.error("msg does not have address: " + msg.toString());
+            return;
+          }
+          doSendOrPub(socket, address, msg, registry, replies);
+        },
+        () -> sendErrFrame("blocked by bridgeEvent handler", socket));
+    });
+
+    socket.handler(parser);
+
+    socket.exceptionHandler(t -> {
+      log.error(t.getMessage(), t);
+      registry.values().forEach(MessageConsumer::unregister);
+      registry.clear();
+      socket.close();
+    });
+
+    socket.endHandler(v -> {
+      registry.values().forEach(MessageConsumer::unregister);
+      registry.clear();
+    });
+  }
+
+  private void doSendOrPub(NetSocket socket, String address, JsonObject msg, Map<String,
+    MessageConsumer<?>> registry, Map<String, Message<JsonObject>> replies) {
+    final JsonObject body = msg.getJsonObject("body");
+    final JsonObject headers = msg.getJsonObject("headers");
+
+    // default to message
+    final String type = msg.getString("type", "message");
+    DeliveryOptions deliveryOptions = parseMsgHeaders(new DeliveryOptions(), headers);
+
+    switch (type) {
+      case "send":
+        if (bridge.checkMatches(true, address, replies)) {
+          final String replyAddress = msg.getString("replyAddress");
+
+          if (replyAddress != null) {
+            // reply address is not null, it is a request from TCP endpoint that will wait for a response
+            eventBus.request(address, body, deliveryOptions, (AsyncResult<Message<JsonObject>> res1) -> {
+              if (res1.failed()) {
+                sendErrFrame(address, replyAddress, (ReplyException) res1.cause(), socket);
+              } else {
+                final Message<JsonObject> response = res1.result();
+                final JsonObject responseHeaders = new JsonObject();
+
+                // clone the headers from / to
+                for (Map.Entry<String, String> entry : response.headers()) {
+                  responseHeaders.put(entry.getKey(), entry.getValue());
+                }
+
+                if (response.replyAddress() != null) {
+                  replies.put(response.replyAddress(), response);
+                }
+
+                sendFrame("message", replyAddress, response.replyAddress(), responseHeaders, true, response.body(), socket);
+              }
+            });
+          } else {
+            // no reply address it might be a response, a failure or a request that does not need a response
+            if (replies.containsKey(address)) {
+              // address is registered, it is not a request
+              Integer failureCode = msg.getInteger("failureCode");
+              if ( failureCode == null ) {
+                //No failure code, it is a response
+                replies.get(address).reply(body, deliveryOptions);
+              } else {
+                //Failure code, fail the original response
+                replies.get(address).fail(msg.getInteger("failureCode"), msg.getString("message"));
+              }
+            } else {
+              // it is a request that does not expect a response
+              eventBus.send(address, body, deliveryOptions);
+            }
+          }
+          // replies are a one time off operation
+          replies.remove(address);
+        } else {
+          sendErrFrame("access_denied", socket);
+        }
+        break;
+      case "publish":
+        if (bridge.checkMatches(true, address)) {
+          eventBus.publish(address, body, deliveryOptions);
+        } else {
+          sendErrFrame("access_denied", socket);
+        }
+        break;
+      case "register":
+        if (bridge.checkMatches(false, address)) {
+          registry.put(address, eventBus.consumer(address, (Message<JsonObject> res1) -> {
+            // save a reference to the message so tcp bridged messages can be replied properly
+            if (res1.replyAddress() != null) {
+              replies.put(res1.replyAddress(), res1);
+            }
+
+            final JsonObject responseHeaders = new JsonObject();
+
+            // clone the headers from / to
+            for (Map.Entry<String, String> entry : res1.headers()) {
+              responseHeaders.put(entry.getKey(), entry.getValue());
+            }
+
+            sendFrame("message", res1.address(), res1.replyAddress(), responseHeaders, res1.isSend(), res1.body(), socket);
+          }));
+          checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, msg, socket), null, null);
+        } else {
+          sendErrFrame("access_denied", socket);
+        }
+        break;
+      case "unregister":
+        if (bridge.checkMatches(false, address)) {
+          MessageConsumer<?> consumer = registry.remove(address);
+          if (consumer != null) {
+            consumer.unregister();
+          } else {
+            sendErrFrame("unknown_address", socket);
+          }
+        } else {
+          sendErrFrame("access_denied", socket);
+        }
+        break;
+      case "ping":
+        sendFrame("pong", socket);
+        break;
+      default:
+        sendErrFrame("unknown_type", socket);
+        break;
+    }
+  }
+
+  private void checkCallHook(Supplier<BridgeEventImpl> eventSupplier, Runnable okAction, Runnable rejectAction) {
+    if (bridgeEventHandler == null) {
+      if (okAction != null) {
+        okAction.run();
+      }
+    } else {
+      BridgeEventImpl event = eventSupplier.get();
+      bridgeEventHandler.handle(event);
+      event.future().onComplete(res -> {
+        if (res.succeeded()) {
+          if (res.result()) {
+            if (okAction != null) {
+              okAction.run();
+            }
+          } else {
+            if (rejectAction != null) {
+              rejectAction.run();
+            } else {
+              log.debug("Bridge handler prevented send or pub");
+            }
+          }
+        } else {
+          log.error("Failure in bridge event handler", res.cause());
+        }
+      });
+    }
+  }
+
+  private DeliveryOptions parseMsgHeaders(DeliveryOptions options, JsonObject headers) {
+    if (headers == null)
+      return options;
+    Iterator<String> fnameIter = headers.fieldNames().iterator();
+    String fname;
+    while (fnameIter.hasNext()) {
+      fname = fnameIter.next();
+      if ("timeout".equals(fname)) {
+        options.setSendTimeout(headers.getLong(fname));
+      } else if ("localOnly".equals(fname)) {
+        options.setLocalOnly(headers.getBoolean(fname));
+      } else if ("codecName".equals(fname)) {
+        options.setCodecName(headers.getString(fname));
+      } else {
+        options.addHeader(fname, headers.getString(fname));
+      }
+    }
+    return options;
+  }
+
+  private static BridgeEventType parseType(String typeStr) {
+    switch (typeStr) {
+      case "ping":
+        return BridgeEventType.SOCKET_PING;
+      case "register":
+        return BridgeEventType.REGISTER;
+      case "unregister":
+        return BridgeEventType.UNREGISTER;
+      case "publish":
+        return BridgeEventType.PUBLISH;
+      case "send":
+        return BridgeEventType.SEND;
+      default:
+        throw new IllegalArgumentException("Invalid frame type " + typeStr);
+    }
+  }
+
+}

--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeHandler.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeHandler.java
@@ -81,6 +81,10 @@ class TcpEventBusBridgeHandler implements Handler<NetSocket> {
       final String type = msg.getString("type", "message");
       final String address = msg.getString("address");
       BridgeEventType eventType = parseType(type);
+      if (eventType == null) {
+        sendErrFrame("unknown_type", socket);
+        return;
+      }
       checkCallHook(() -> new BridgeEventImpl(eventType, msg, socket),
         () -> {
           if (eventType != BridgeEventType.SOCKET_PING && address == null) {
@@ -277,7 +281,7 @@ class TcpEventBusBridgeHandler implements Handler<NetSocket> {
       case "send":
         return BridgeEventType.SEND;
       default:
-        throw new IllegalArgumentException("Invalid frame type " + typeStr);
+        return null;
     }
   }
 

--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeImpl.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/TcpEventBusBridgeImpl.java
@@ -19,31 +19,20 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.*;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.NetSocket;
-import io.vertx.ext.bridge.BridgeEventType;
 import io.vertx.ext.bridge.BridgeOptions;
 import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.eventbus.bridge.tcp.BridgeEvent;
 import io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge;
-import io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameParser;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameHelper.sendErrFrame;
-import static io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameHelper.sendFrame;
 
 /**
  * Abstract TCP EventBus bridge. Handles all common socket operations but has no knowledge on the payload.
@@ -52,29 +41,20 @@ import static io.vertx.ext.eventbus.bridge.tcp.impl.protocol.FrameHelper.sendFra
  */
 public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
 
-  private static final Logger log = LoggerFactory.getLogger(TcpEventBusBridgeImpl.class);
-
-  private final EventBus eb;
   private final NetServer server;
 
   private final Map<String, Pattern> compiledREs = new HashMap<>();
   private final BridgeOptions options;
-  private final Handler<BridgeEvent> bridgeEventHandler;
-
 
   public TcpEventBusBridgeImpl(Vertx vertx, BridgeOptions options, NetServerOptions netServerOptions, Handler<BridgeEvent> eventHandler) {
-    this.eb = vertx.eventBus();
     this.options = options != null ? options : new BridgeOptions();
-    this.bridgeEventHandler = eventHandler;
-
     server = vertx.createNetServer(netServerOptions == null ? new NetServerOptions() : netServerOptions);
-    server.connectHandler(this::handler);
+    server.connectHandler(new TcpEventBusBridgeHandler(this, vertx.eventBus(), eventHandler));
   }
 
   public TcpEventBusBridgeImpl(Vertx vertx, BridgeOptions options, NetServerOptions netServerOptions) {
     this(vertx, options, netServerOptions, null);
   }
-
 
   @Override
   public Future<TcpEventBusBridge> listen() {
@@ -127,163 +107,6 @@ public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
     return this;
   }
 
-  private void doSendOrPub(NetSocket socket, String address, JsonObject msg, Map<String,
-    MessageConsumer<?>> registry, Map<String, Message<JsonObject>> replies) {
-    final JsonObject body = msg.getJsonObject("body");
-    final JsonObject headers = msg.getJsonObject("headers");
-
-
-    // default to message
-    final String type = msg.getString("type", "message");
-    DeliveryOptions deliveryOptions = parseMsgHeaders(new DeliveryOptions(), headers);
-
-    switch (type) {
-      case "send":
-        if (checkMatches(true, address, replies)) {
-          final String replyAddress = msg.getString("replyAddress");
-
-          if (replyAddress != null) {
-            // reply address is not null, it is a request from TCP endpoint that will wait for a response
-            eb.request(address, body, deliveryOptions, (AsyncResult<Message<JsonObject>> res1) -> {
-              if (res1.failed()) {
-                sendErrFrame(address, replyAddress, (ReplyException) res1.cause(), socket);
-              } else {
-                final Message<JsonObject> response = res1.result();
-                final JsonObject responseHeaders = new JsonObject();
-
-                // clone the headers from / to
-                for (Map.Entry<String, String> entry : response.headers()) {
-                  responseHeaders.put(entry.getKey(), entry.getValue());
-                }
-
-                if (response.replyAddress() != null) {
-                  replies.put(response.replyAddress(), response);
-                }
-
-                sendFrame("message", replyAddress, response.replyAddress(), responseHeaders, true, response.body(), socket);
-              }
-            });
-          } else {
-            // no reply address it might be a response, a failure or a request that does not need a response
-            if (replies.containsKey(address)) {
-              // address is registered, it is not a request
-              Integer failureCode = msg.getInteger("failureCode");
-              if ( failureCode == null ) {
-                //No failure code, it is a response
-                replies.get(address).reply(body, deliveryOptions);
-              } else {
-                //Failure code, fail the original response
-                replies.get(address).fail(msg.getInteger("failureCode"), msg.getString("message"));
-              }
-            } else {
-              // it is a request that does not expect a response
-              eb.send(address, body, deliveryOptions);
-            }
-          }
-          // replies are a one time off operation
-          replies.remove(address);
-        } else {
-          sendErrFrame("access_denied", socket);
-        }
-        break;
-      case "publish":
-        if (checkMatches(true, address)) {
-          eb.publish(address, body, deliveryOptions);
-        } else {
-          sendErrFrame("access_denied", socket);
-        }
-        break;
-      case "register":
-        if (checkMatches(false, address)) {
-          registry.put(address, eb.consumer(address, (Message<JsonObject> res1) -> {
-            // save a reference to the message so tcp bridged messages can be replied properly
-            if (res1.replyAddress() != null) {
-              replies.put(res1.replyAddress(), res1);
-            }
-
-            final JsonObject responseHeaders = new JsonObject();
-
-            // clone the headers from / to
-            for (Map.Entry<String, String> entry : res1.headers()) {
-              responseHeaders.put(entry.getKey(), entry.getValue());
-            }
-
-            sendFrame("message", res1.address(), res1.replyAddress(), responseHeaders, res1.isSend(), res1.body(), socket);
-          }));
-          checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, msg, socket), null, null);
-        } else {
-          sendErrFrame("access_denied", socket);
-        }
-        break;
-      case "unregister":
-        if (checkMatches(false, address)) {
-          MessageConsumer<?> consumer = registry.remove(address);
-          if (consumer != null) {
-            consumer.unregister();
-          } else {
-            sendErrFrame("unknown_address", socket);
-          }
-        } else {
-          sendErrFrame("access_denied", socket);
-        }
-        break;
-      case "ping":
-        sendFrame("pong", socket);
-        break;
-      default:
-        sendErrFrame("unknown_type", socket);
-        break;
-    }
-  }
-
-  private void handler(NetSocket socket) {
-
-    final Map<String, MessageConsumer<?>> registry = new ConcurrentHashMap<>();
-    final Map<String, Message<JsonObject>> replies = new ConcurrentHashMap<>();
-
-    // create a protocol parser
-    final FrameParser parser = new FrameParser(res -> {
-      if (res.failed()) {
-        // could not parse the message properly
-        log.error(res.cause());
-        return;
-      }
-
-      final JsonObject msg = res.result();
-
-      // short reference
-
-      // default to message
-      final String type = msg.getString("type", "message");
-      final String address = msg.getString("address");
-      BridgeEventType eventType = parseType(type);
-      checkCallHook(() -> new BridgeEventImpl(eventType, msg, socket),
-        () -> {
-          if (eventType != BridgeEventType.SOCKET_PING && address == null) {
-            sendErrFrame("missing_address", socket);
-            log.error("msg does not have address: " + msg.toString());
-            return;
-          }
-          doSendOrPub(socket, address, msg, registry, replies);
-        },
-        () -> sendErrFrame("blocked by bridgeEvent handler", socket));
-    });
-
-    socket.handler(parser);
-
-    socket.exceptionHandler(t -> {
-      log.error(t.getMessage(), t);
-      registry.values().forEach(MessageConsumer::unregister);
-      registry.clear();
-      socket.close();
-    });
-
-    socket.endHandler(v -> {
-      registry.values().forEach(MessageConsumer::unregister);
-      registry.clear();
-    });
-  }
-
   @Override
   public void close(Handler<AsyncResult<Void>> handler) {
     server.close(handler);
@@ -294,39 +117,11 @@ public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
     return server.close();
   }
 
-  private void checkCallHook(Supplier<BridgeEventImpl> eventSupplier, Runnable okAction, Runnable rejectAction) {
-    if (bridgeEventHandler == null) {
-      if (okAction != null) {
-        okAction.run();
-      }
-    } else {
-      BridgeEventImpl event = eventSupplier.get();
-      bridgeEventHandler.handle(event);
-      event.future().onComplete(res -> {
-        if (res.succeeded()) {
-          if (res.result()) {
-            if (okAction != null) {
-              okAction.run();
-            }
-          } else {
-            if (rejectAction != null) {
-              rejectAction.run();
-            } else {
-              log.debug("Bridge handler prevented send or pub");
-            }
-          }
-        } else {
-          log.error("Failure in bridge event handler", res.cause());
-        }
-      });
-    }
-  }
-
-  private boolean checkMatches(boolean inbound, String address) {
+  boolean checkMatches(boolean inbound, String address) {
     return checkMatches(inbound, address, null);
   }
 
-  private boolean checkMatches(boolean inbound, String address, Map<String, Message<JsonObject>> replies) {
+  boolean checkMatches(boolean inbound, String address, Map<String, Message<JsonObject>> replies) {
     // special case, when dealing with replies the addresses are not in the inbound/outbound list but on
     // the replies registry
     if (replies != null && inbound && replies.containsKey(address)) {
@@ -369,42 +164,4 @@ public class TcpEventBusBridgeImpl implements TcpEventBusBridge {
     return m.matches();
   }
 
-  private DeliveryOptions parseMsgHeaders(DeliveryOptions options, JsonObject headers) {
-    if (headers == null)
-      return options;
-
-    Iterator<String> fnameIter = headers.fieldNames().iterator();
-    String fname;
-    while (fnameIter.hasNext()) {
-      fname = fnameIter.next();
-      if ("timeout".equals(fname)) {
-          options.setSendTimeout(headers.getLong(fname));
-      } else if ("localOnly".equals(fname)) {
-          options.setLocalOnly(headers.getBoolean(fname));
-      } else if ("codecName".equals(fname)) {
-          options.setCodecName(headers.getString(fname));
-      } else {
-        options.addHeader(fname, headers.getString(fname));
-      }
-    }
-
-    return options;
-  }
-
-  private static BridgeEventType parseType(String typeStr) {
-    switch (typeStr) {
-      case "ping":
-        return BridgeEventType.SOCKET_PING;
-      case "register":
-        return BridgeEventType.REGISTER;
-      case "unregister":
-          return BridgeEventType.UNREGISTER;
-      case "publish":
-        return BridgeEventType.PUBLISH;
-      case "send":
-        return BridgeEventType.SEND;
-      default:
-        throw new IllegalArgumentException("Invalid frame type " + typeStr);
-    }
-  }
 }

--- a/src/test/java/io/vertx/ext/eventbus/bridge/tcp/TcpEventBusBridgeTest.java
+++ b/src/test/java/io/vertx/ext/eventbus/bridge/tcp/TcpEventBusBridgeTest.java
@@ -464,4 +464,54 @@ public class TcpEventBusBridgeTest {
     }));
   }
 
+  @Test
+  public void testSendNonJsonObjectBody(TestContext context) {
+    NetClient client = vertx.createNetClient();
+    final Async async = context.async();
+    final FrameParser parser = new FrameParser(parse -> {
+      context.assertTrue(parse.succeeded());
+      JsonObject frame = parse.result();
+      context.assertEquals("err", frame.getString("type"));
+      context.assertEquals("wrong_format", frame.getString("message"));
+      vertx.setTimer(200, l -> {
+        client.close();
+        async.complete();
+      });
+    });
+    client.connect(7000, "localhost", context.asyncAssertSuccess(socket -> {
+      socket.handler(parser);
+      JsonObject payload = new JsonObject()
+        .put("type", "send")
+        .put("address", "echo")
+        .put("body", "String value")
+        ;
+      FrameHelper.writeFrame(payload, socket);
+    }));
+  }
+
+  @Test
+  public void testSendNonJsonObjectHeaders(TestContext context) {
+    NetClient client = vertx.createNetClient();
+    final Async async = context.async();
+    final FrameParser parser = new FrameParser(parse -> {
+      context.assertTrue(parse.succeeded());
+      JsonObject frame = parse.result();
+      context.assertEquals("err", frame.getString("type"));
+      context.assertEquals("wrong_format", frame.getString("message"));
+      vertx.setTimer(200, l -> {
+        client.close();
+        async.complete();
+      });
+    });
+    client.connect(7000, "localhost", context.asyncAssertSuccess(socket -> {
+      socket.handler(parser);
+      JsonObject payload = new JsonObject()
+        .put("type", "send")
+        .put("address", "echo")
+        .put("headers", "non-json-object-headers")
+        ;
+      FrameHelper.writeFrame(payload, socket);
+    }));
+  }
+
 }

--- a/src/test/java/io/vertx/ext/eventbus/bridge/tcp/TcpEventBusBridgeTest.java
+++ b/src/test/java/io/vertx/ext/eventbus/bridge/tcp/TcpEventBusBridgeTest.java
@@ -439,4 +439,29 @@ public class TcpEventBusBridgeTest {
     }));
   }
 
+  @Test
+  public void testSendWrongType(TestContext context) {
+    NetClient client = vertx.createNetClient();
+    final Async async = context.async();
+    final FrameParser parser = new FrameParser(parse -> {
+      context.assertTrue(parse.succeeded());
+      JsonObject frame = parse.result();
+      context.assertEquals("err", frame.getString("type"));
+      context.assertEquals("unknown_type", frame.getString("message"));
+      vertx.setTimer(200, l -> {
+        client.close();
+        async.complete();
+      });
+    });
+    client.connect(7000, "localhost", context.asyncAssertSuccess(socket -> {
+      socket.handler(parser);
+      JsonObject payload = new JsonObject()
+        .put("type", "typeA")
+        .put("address", "echo")
+        .put("body", "String value")
+        ;
+      FrameHelper.writeFrame(payload, socket);
+    }));
+  }
+
 }


### PR DESCRIPTION
Motivation:

Fixes: #58 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

This PR contains 3 commits to improve robustness:
* First commit splits `TcpEventBusBridgeHandler` out of `TcpEventBusBridgeImpl` which makes it cleaner to handle socket communications.
* Second commit fix the issue when the type of the message is not supported.
* Third commit fix the issue when `body` or `headers` are malformed values