### PR TITLE
Fix build status link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vertx-tcp-eventbus-bridge
 
-[![Build Status](https://github.com/vert-x3/vertx-tcm-eventbus-bridge/workflows/CI/badge.svg?branch=master)](https://github.com/vert-x3/vertx-tcp-eventbus-bridge/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/vert-x3/vertx-tcp-eventbus-bridge/workflows/CI/badge.svg?branch=master)](https://github.com/vert-x3/vertx-tcp-eventbus-bridge/actions?query=workflow%3ACI)
 
 This is a TCP eventbus bridge implementation.
 


### PR DESCRIPTION
Motivation:

The build status in READEME.md has a typo.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
