### PR TITLE
Fix #61: message body should not be locked to JSON Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It is the response to the `ping` request from client to bridge.
 For a regular message, the object will also contain:
 
 * `address`: (string, required) Destination address.
-* `body`: (object, required) Message content as a JSON object.
+* `body`: (any, required) Message content as a JSON valid type.
 * `headers`: (object, optional) Headers as a JSON object with String values.
 * `replyAddress`: (string, optional) Address for replying to.
 * `send`: (boolean, required) Will be `true` if the message is a send, `false` if a publish.
@@ -54,7 +54,7 @@ type is shown below, along with the companion keys for that type:
 #### `type: "send"`, `type: "publish"`
 
 * `address`: (string, required) Destination address
-* `body`: (object, required) Message content as a JSON object.
+* `body`: (any, required) Message content as a JSON valid type.
 * `headers`: (object, optional) Headers as a JSON object with String values.
 * `replyAddress`: (string, optional) Address for replying to.
 

--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/protocol/FrameHelper.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/protocol/FrameHelper.java
@@ -21,6 +21,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.streams.WriteStream;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Helper class to format and send frames over a socket
@@ -28,11 +29,11 @@ import java.nio.charset.Charset;
  */
 public class FrameHelper {
 
-  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   private FrameHelper() {}
 
-  public static void sendFrame(String type, String address, String replyAddress, JsonObject headers, Boolean send, JsonObject body, WriteStream<Buffer> handler) {
+  public static void sendFrame(String type, String address, String replyAddress, JsonObject headers, Boolean send, Object body, WriteStream<Buffer> handler) {
     final JsonObject payload = new JsonObject().put("type", type);
 
     if (address != null) {
@@ -58,11 +59,11 @@ public class FrameHelper {
     writeFrame(payload, handler);
   }
 
-  public static void sendFrame(String type, String address, String replyAddress, JsonObject body, WriteStream<Buffer> handler) {
+  public static void sendFrame(String type, String address, String replyAddress, Object body, WriteStream<Buffer> handler) {
     sendFrame(type, address, replyAddress, null, null, body, handler);
   }
 
-  public static void sendFrame(String type, String address, JsonObject body, WriteStream<Buffer> handler) {
+  public static void sendFrame(String type, String address, Object body, WriteStream<Buffer> handler) {
     sendFrame(type, address, null, null, null, body, handler);
   }
 


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

The bridge internals were assuming message body ws always JSON Object. This was a wrong assumption as can be seen on the client implementations.

This PR addresses the issue by changing the internals to not assume JSON Object but any valid type.
