### PR TITLE
Fix tests for experimental JSON-RPC bridge

### DIFF
--- a/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/JsonRPCStreamEventBusBridgeImpl.java
+++ b/src/main/java/io/vertx/ext/eventbus/bridge/tcp/impl/JsonRPCStreamEventBusBridgeImpl.java
@@ -238,13 +238,13 @@ public class JsonRPCStreamEventBusBridgeImpl implements JsonRPCStreamEventBusBri
         // no reply address it might be a response, a failure or a request that does not need a response
         if (replies.containsKey(address)) {
           // address is registered, it is not a request
-          Integer failureCode = msg.getInteger("failureCode");
-          if (failureCode == null) {
-            //No failure code, it is a response
+          final JsonObject error = params.getJsonObject("error");
+          if (error == null) {
+            // No error block, it is a response
             replies.get(address).reply(body, deliveryOptions);
           } else {
-            //Failure code, fail the original response
-            replies.get(address).fail(msg.getInteger("failureCode"), msg.getString("message"));
+            // error block, fail the original response
+            replies.get(address).fail(error.getInteger("failureCode"), error.getString("message"));
           }
         } else {
           // it is a request that does not expect a response

--- a/src/test/java/io/vertx/ext/eventbus/bridge/tcp/JsonRPCStreamEventBusBridgeTest.java
+++ b/src/test/java/io/vertx/ext/eventbus/bridge/tcp/JsonRPCStreamEventBusBridgeTest.java
@@ -572,13 +572,6 @@ public class JsonRPCStreamEventBusBridgeTest {
     client.connect(7000, "localhost", should.asyncAssertSuccess(socket -> {
       socket.handler(parser);
       request(
-        "register",
-        "#backtrack",
-        new JsonObject()
-          .put("address", "echo"),
-        socket);
-
-      request(
         "ping",
         "#backtrack",
         socket);

--- a/src/test/java/io/vertx/ext/eventbus/bridge/tcp/JsonRPCStreamEventBusBridgeTest.java
+++ b/src/test/java/io/vertx/ext/eventbus/bridge/tcp/JsonRPCStreamEventBusBridgeTest.java
@@ -184,6 +184,7 @@ public class JsonRPCStreamEventBusBridgeTest {
         .exceptionHandler(should::fail)
         .handler((mimeType, body) -> {
           JsonObject frame = new JsonObject(body);
+          System.out.println(body);
 
           if (!ack.getAndSet(true)) {
             should.assertFalse(frame.containsKey("error"));
@@ -196,7 +197,7 @@ public class JsonRPCStreamEventBusBridgeTest {
 
             JsonObject result = frame.getJsonObject("result");
 
-            should.assertEquals(true, result.getBoolean("send"));
+            should.assertEquals(true, result.getBoolean("isSend"));
             should.assertEquals("hi", result.getJsonObject("body").getString("value"));
             client.close();
             test.complete();
@@ -640,8 +641,8 @@ public class JsonRPCStreamEventBusBridgeTest {
         if (!errorOnce.compareAndSet(false, true)) {
           should.fail("Client gets error message twice!");
         } else {
-          should.assertEquals("err", frame.getString("type"));
-          should.assertEquals("missing_address", frame.getString("message"));
+          should.assertTrue(frame.containsKey("error"));
+          should.assertEquals("invalid_parameters", frame.getJsonObject("error").getString("message"));
           vertx.setTimer(200, l -> {
             client.close();
             test.complete();

--- a/src/test/java/io/vertx/ext/eventbus/bridge/tcp/JsonRPCStreamEventBusBridgeTest.java
+++ b/src/test/java/io/vertx/ext/eventbus/bridge/tcp/JsonRPCStreamEventBusBridgeTest.java
@@ -184,7 +184,6 @@ public class JsonRPCStreamEventBusBridgeTest {
         .exceptionHandler(should::fail)
         .handler((mimeType, body) -> {
           JsonObject frame = new JsonObject(body);
-          System.out.println(body);
 
           if (!ack.getAndSet(true)) {
             should.assertFalse(frame.containsKey("error"));
@@ -193,7 +192,7 @@ public class JsonRPCStreamEventBusBridgeTest {
           } else {
             should.assertFalse(frame.containsKey("error"));
             should.assertTrue(frame.containsKey("result"));
-            should.assertNotEquals("#backtrack", frame.getValue("id"));
+            should.assertEquals("#backtrack", frame.getValue("id"));
 
             JsonObject result = frame.getJsonObject("result");
 


### PR DESCRIPTION
#56 describes the rationale for adding a JSON-RPC bridge. The `experimental/jsonrpc` branch has an initial implementation for the bridge but some of the tests are failing. This PR fixes those tests.

Many of the failing tests were because the tests were not expecting some messages but the bridge was sending them. For instance, when using the Vert.x protocol bridge the client does not receive a message confirming registration but the JSON-RPC spec mandates a response for all requests (except notifications) so the JSON-RPC protocol bridge responds with a ack for register message. The test being modelled on lines of the Vertx protocol tests does not expect this message and hence fails.

This PR updates the tests to handle such messages. I have tried to add comments to explain the logic behind the changes and fixed each test in a separate commit with a somewhat detailed commit message. I hope that helps in reviewing the changes and understanding the rationale behind the fixes.

Apart from this issue, there is one implementation issue in the JSON-RPC bridge - namely, handling response from client to bridge marking an error. The JSON-RPC bridge expect the message to be similar to Vertx one and hence does not handle it well. I have updated the implementation there to expect a JSON-RPC looking message. However, that format is not set in stone since I don't think the spec covers the case of a client sending a error message to the bridge.